### PR TITLE
Fix cross-architecture builds by pinning platform to linux/amd64

### DIFF
--- a/script/Prelude
+++ b/script/Prelude
@@ -4,6 +4,7 @@ run_haskell() {
   set +u
   docker run \
       --rm \
+      --platform linux/amd64 \
       -ti \
       -e LC_ALL=C.UTF-8 \
       -v "$DIR/:/opt/build" \
@@ -21,12 +22,13 @@ run_node() {
   set +u
   docker run \
       --rm \
+      --platform linux/amd64 \
       -e HOME=/opt/build/obj \
       -ti \
       -u "$(id -u "${USER}"):$(id -g "${USER}")" \
       -v "$DIR/js:/opt/build" \
       -w /opt/build \
-      node:14.3 \
+      node:20 \
         $1 $2 $3 $4 $5 $6 $7 $8 $9
   set -u
 }

--- a/script/update
+++ b/script/update
@@ -12,6 +12,7 @@ mkdir -p "$DIR/obj"
 mkdir -p "$DIR/dist-newstyle"
 
 docker build \
+  --platform linux/amd64 \
   -t lorcan/haskell-build:$GHC_VERSION \
   --build-arg GHC_VERSION=$GHC_VERSION \
   --file "$DIR/containers/haskell-build.Dockerfile" \
@@ -26,6 +27,7 @@ run_node "./node_modules/.bin/webpack" \
   --mode=production
 
 docker build \
+  --platform linux/amd64 \
   -t lorcan/regex-candidates \
   --build-arg GHC_VERSION=$GHC_VERSION \
   --file "$DIR/containers/service.Dockerfile" "$DIR"


### PR DESCRIPTION
Without explicit --platform flags, Docker defaults to the host architecture,
producing ARM64 images on Apple Silicon that fail on x86 Linux hosts. Cabal
also outputs binaries to aarch64-linux paths, breaking the x86_64-linux
paths hardcoded in service.Dockerfile and script/test.

Also upgrades node:14.3 (EOL) to node:20 LTS for reliable amd64 image
availability.

https://claude.ai/code/session_01XRo9oxCKx88ZtE3QyVFhdg